### PR TITLE
fix(doc): `get_key` return type is not correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 ## Reference
 
 ### `get_key`
-> Signature: `() -> None`
+> Signature: `() -> str`
 
 Returns a keypress from standard input. It exclusively identifies keypresses
 that result in tangible inputs, therefore modifier keys like `shift` or


### PR DESCRIPTION
It is marked as being `None`, where in reality it is `str`.